### PR TITLE
Remove benchmark label before run

### DIFF
--- a/.github/workflows/cb.yml
+++ b/.github/workflows/cb.yml
@@ -21,6 +21,13 @@ jobs:
              )
             )
         steps:
+            - name: Remove benchmark label (so it can be re-triggered afterwards)
+              run: |
+               curl --silent --fail-with-body \
+                  -X DELETE \
+                  -H 'Accept: application/vnd.github.v3+json' \
+                  -H 'Authorization: token ${{ github.token }}' \
+                  'https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels/benchmark'
             - name: Checkout
               uses: actions/checkout@v4
             - name: Mirror and get status

--- a/.github/workflows/cb.yml
+++ b/.github/workflows/cb.yml
@@ -22,6 +22,7 @@ jobs:
             )
         steps:
             - name: Remove benchmark label (so it can be re-triggered afterwards)
+              if: ${{ github.event_name == 'pull_request_target' }}
               run: |
                curl --silent --fail-with-body \
                   -X DELETE \


### PR DESCRIPTION
This way, it's easy to re-trigger after the next push